### PR TITLE
Adds Nuget package build support to project

### DIFF
--- a/H3Lib/H3Lib.csproj
+++ b/H3Lib/H3Lib.csproj
@@ -22,6 +22,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AssemblyName>h3net</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/H3Lib/H3Lib.csproj
+++ b/H3Lib/H3Lib.csproj
@@ -19,6 +19,9 @@
     <FileVersion>3.7.1</FileVersion>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
This adds the project file fields to enable package output.

This produces two files under `bin\Release\`:

1. `H3Lib.{version}.nupkg` : Nuget Package
2. `H3Lib.{version}.snupkg` : Symbol File

These would just need to be uploaded to nuget.org

________________________________________________

Resolves #19 